### PR TITLE
Fix: Explicitly set packages write permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,6 +17,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}


### PR DESCRIPTION
# Purpose

Explicitly set packages write permissions (even though they should be default) so that pushing the docker container works.

Context:
* Failed push: https://github.com/michalfita/packer-plugin-cross/actions/runs/7332136106/job/19977209274
* Successful push in my fork (without relevant more changes): https://github.com/dbast/packer-plugin-cross/actions/runs/7332250196/job/19966118406
* Upstream discussion https://github.com/docker/build-push-action/issues/687 