### PR TITLE
Fixes typo in `test.yml`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Test CI & Vagrant (MacOS)
 on:
   push:
     tags:


### PR DESCRIPTION
## Purpose
~These changes fixed Vagrant CI in #13, so I bring it here separately before **release**.~
This fixes only a typo.