### PR TITLE
Fix: Update release workflow and make it PR testable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,27 +5,44 @@ on:
   push:
     tags:
       - 'v*'
+    branches:
+      - master
+  pull_request:
 
 jobs:
   plugin-release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.20
+          go-version: 1.21
       - name: Describe plugin
         id: plugin_describe
         run: echo "api_version=$(go run . describe | jq -r '.api_version')" >> $GITHUB_OUTPUT
       - name: Run GoReleaser Action
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@v5
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           API_VERSION: ${{ steps.plugin_describe.outputs.api_version }}
+      - name: Run GoReleaser Action (skip-publish)
+        uses: goreleaser/goreleaser-action@v5
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        with:
+          version: latest
+          args: release --clean --skip-publish --snapshot
+        env:
+          API_VERSION: ${{ steps.plugin_describe.outputs.api_version }}
+      - name: Upload assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: packer-plugin-cross
+          path: dist/*


### PR DESCRIPTION
This solves the error (and deprecation note) which can be seen here https://github.com/michalfita/packer-plugin-cross/actions/runs/7340316453/job/19986140955:
* `2023/12/27 17:00:50 unsupported GOARCH arm64`
* `DEPRECATED: --rm-dist was deprecated in favor of --clean`

Also save the build output as downloadable artifacts for local testing. The artifacts link can be found in the workflow summary at the botom https://github.com/michalfita/packer-plugin-cross/actions/runs/7345549277?pr=17

(PR is done against master branch and should allow doing a 1.1.1 release)

closes https://github.com/michalfita/packer-plugin-cross/discussions/16