### PR TITLE
Fix: Explicitly set permissions for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: write
+
 jobs:
   plugin-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
See also https://github.com/goreleaser/goreleaser-action#workflow

fixes https://github.com/michalfita/packer-plugin-cross/discussions/16