### PR TITLE
[Fixes #72] Add loopback partition check with delay

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,6 +70,7 @@ jobs:
           - odroid-xu4/ubuntu.pkr.hcl
           - parallella/archlinuxarm.pkr.hcl
           - parallella/ubuntu.pkr.hcl
+          - raspberry-pi/alpine-v3.22.1_aarch64.pkr.hcl
           - raspberry-pi/archlinuxarm.pkr.hcl
           - raspberry-pi/raspbian.pkr.hcl
           - raspberry-pi/raspbian-resize.pkr.hcl

--- a/boards/raspberry-pi/alpine-v3.22.1_aarch64.pkr.hcl
+++ b/boards/raspberry-pi/alpine-v3.22.1_aarch64.pkr.hcl
@@ -32,13 +32,13 @@ source "cross" "alpine" {
 build {
   sources = ["source.cross.alpine"]
 
-  provisioner "file" {
-    sources = [
-      "files/boot/cmdline.txt",
-      "files/boot/config.txt",
-      "files/boot/start4x.elf",
-      "files/boot/fixup4x.dat"
-    ]
-    destination = "/boot/firmware"
-  }
+  # provisioner "file" {
+  #    sources = [
+  #     "files/boot/cmdline.txt",
+  #     "files/boot/config.txt",
+  #     "files/boot/start4x.elf",
+  #     "files/boot/fixup4x.dat"
+  #   ]
+  #   destination = "/boot/firmware"
+  # }
 }

--- a/boards/raspberry-pi/alpine-v3.22.1_aarch64.pkr.hcl
+++ b/boards/raspberry-pi/alpine-v3.22.1_aarch64.pkr.hcl
@@ -1,0 +1,44 @@
+source "cross" "alpine" {
+  file_urls = ["https://dl-cdn.alpinelinux.org/alpine/v3.22/releases/aarch64/alpine-rpi-3.22.1-aarch64.tar.gz"]
+  file_checksum_url = "https://dl-cdn.alpinelinux.org/alpine/v3.22/releases/aarch64/alpine-rpi-3.22.1-aarch64.tar.gz.sha256"
+  file_checksum_type = "sha256"
+  file_target_extension = "tar.gz"
+  file_unarchive_cmd    = ["bsdtar", "-xpf", "$ARCHIVE_PATH", "-C", "$MOUNTPOINT"]
+
+  image_build_method    = "new"
+  image_path = "stage1_picam.img"
+  image_size = "6G"
+  image_type = "dos"
+  image_partitions {
+    filesystem = "vfat"
+    mountpoint = "/boot"
+    name = "boot"
+    size = "256M"
+    start_sector = "2048"
+    type = "c"
+  }
+  image_partitions {
+    filesystem = "ext4"
+    mountpoint = "/"
+    name = "root"
+    size = "0"
+    start_sector = "526336"
+    type = "83"
+  }
+  qemu_binary_source_path = "/usr/bin/qemu-aarch64-static"
+  qemu_binary_destination_path = "/usr/bin/qemu-aarch64-static"
+}
+
+build {
+	sources = ["source.cross.alpine"]
+
+	provisioner "file" {
+		sources = [
+			"files/boot/cmdline.txt",
+			"files/boot/config.txt",
+			"files/boot/start4x.elf",
+			"files/boot/fixup4x.dat"
+		]
+		destination = "/boot/firmware"
+	}
+}

--- a/boards/raspberry-pi/alpine-v3.22.1_aarch64.pkr.hcl
+++ b/boards/raspberry-pi/alpine-v3.22.1_aarch64.pkr.hcl
@@ -1,44 +1,44 @@
 source "cross" "alpine" {
-  file_urls = ["https://dl-cdn.alpinelinux.org/alpine/v3.22/releases/aarch64/alpine-rpi-3.22.1-aarch64.tar.gz"]
-  file_checksum_url = "https://dl-cdn.alpinelinux.org/alpine/v3.22/releases/aarch64/alpine-rpi-3.22.1-aarch64.tar.gz.sha256"
-  file_checksum_type = "sha256"
+  file_urls             = ["https://dl-cdn.alpinelinux.org/alpine/v3.22/releases/aarch64/alpine-rpi-3.22.1-aarch64.tar.gz"]
+  file_checksum_url     = "https://dl-cdn.alpinelinux.org/alpine/v3.22/releases/aarch64/alpine-rpi-3.22.1-aarch64.tar.gz.sha256"
+  file_checksum_type    = "sha256"
   file_target_extension = "tar.gz"
   file_unarchive_cmd    = ["bsdtar", "-xpf", "$ARCHIVE_PATH", "-C", "$MOUNTPOINT"]
 
-  image_build_method    = "new"
-  image_path = "stage1_picam.img"
-  image_size = "6G"
-  image_type = "dos"
+  image_build_method = "new"
+  image_path         = "stage1_picam.img"
+  image_size         = "6G"
+  image_type         = "dos"
   image_partitions {
-    filesystem = "vfat"
-    mountpoint = "/boot"
-    name = "boot"
-    size = "256M"
+    filesystem   = "vfat"
+    mountpoint   = "/boot"
+    name         = "boot"
+    size         = "256M"
     start_sector = "2048"
-    type = "c"
+    type         = "c"
   }
   image_partitions {
-    filesystem = "ext4"
-    mountpoint = "/"
-    name = "root"
-    size = "0"
+    filesystem   = "ext4"
+    mountpoint   = "/"
+    name         = "root"
+    size         = "0"
     start_sector = "526336"
-    type = "83"
+    type         = "83"
   }
-  qemu_binary_source_path = "/usr/bin/qemu-aarch64-static"
+  qemu_binary_source_path      = "/usr/bin/qemu-aarch64-static"
   qemu_binary_destination_path = "/usr/bin/qemu-aarch64-static"
 }
 
 build {
-	sources = ["source.cross.alpine"]
+  sources = ["source.cross.alpine"]
 
-	provisioner "file" {
-		sources = [
-			"files/boot/cmdline.txt",
-			"files/boot/config.txt",
-			"files/boot/start4x.elf",
-			"files/boot/fixup4x.dat"
-		]
-		destination = "/boot/firmware"
-	}
+  provisioner "file" {
+    sources = [
+      "files/boot/cmdline.txt",
+      "files/boot/config.txt",
+      "files/boot/start4x.elf",
+      "files/boot/fixup4x.dat"
+    ]
+    destination = "/boot/firmware"
+  }
 }

--- a/builder/step_mkfs_image.go
+++ b/builder/step_mkfs_image.go
@@ -26,13 +26,14 @@ func (s *StepMkfsImage) Run(_ context.Context, state multistep.StateBag) multist
 
 	for i, partition := range config.ImageConfig.ImagePartitions {
 		cmd := fmt.Sprintf("mkfs.%s", partition.Filesystem)
-		args := append(partition.FilesystemMakeOptions, fmt.Sprintf("%sp%d", loopDevice, i+1))
-		
-		if _, err := os.Stat(args[1]); errors.Is(err, os.ErrNotExist) {
-			ui.Error(fmt.Sprintf("partition loopack `%s` doesn't exist immediately after mouting, delaying...", args[1])) // TODO: where's warning?
+		loopPartition := fmt.Sprintf("%sp%d", loopDevice, i+1)
+		args := append(partition.FilesystemMakeOptions, loopPartition)
+
+		if _, err := os.Stat(loopPartition); errors.Is(err, os.ErrNotExist) {
+			ui.Error(fmt.Sprintf("partition loopack `%s` doesn't exist immediately after mouting, delaying...", loopPartition)) // TODO: where's warning?
   			time.Sleep(1 * time.Second)
 			if _, err := os.Stat(args[1]); errors.Is(err, os.ErrNotExist) {
-				ui.Error(fmt.Sprintf("partition loopack `%s` doesn't exist, aborting partition creation", args[1]))
+				ui.Error(fmt.Sprintf("partition loopack `%s` doesn't exist, aborting partition creation", loopPartition))
 				return multistep.ActionHalt
 			}
 		}

--- a/builder/step_mkfs_image.go
+++ b/builder/step_mkfs_image.go
@@ -2,9 +2,12 @@ package builder
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	"github.com/hashicorp/packer-plugin-sdk/packer"
@@ -24,6 +27,15 @@ func (s *StepMkfsImage) Run(_ context.Context, state multistep.StateBag) multist
 	for i, partition := range config.ImageConfig.ImagePartitions {
 		cmd := fmt.Sprintf("mkfs.%s", partition.Filesystem)
 		args := append(partition.FilesystemMakeOptions, fmt.Sprintf("%sp%d", loopDevice, i+1))
+		
+		if _, err := os.Stat(args[1]); errors.Is(err, os.ErrNotExist) {
+			ui.Error(fmt.Sprintf("partition loopack `%s` doesn't exist immediately after mouting, delaying...", args[1])) // TODO: where's warning?
+  			time.Sleep(1 * time.Second)
+			if _, err := os.Stat(args[1]); errors.Is(err, os.ErrNotExist) {
+				ui.Error(fmt.Sprintf("partition loopack `%s` doesn't exist, aborting partition creation", args[1]))
+				return multistep.ActionHalt
+			}
+		}
 
 		ui.Message(fmt.Sprintf("creating partition #%d: mkfs.%s %s", i+1, cmd, strings.Join(args, " ")))
 		out, err := exec.Command(cmd, args...).CombinedOutput()

--- a/builder/step_mkfs_image.go
+++ b/builder/step_mkfs_image.go
@@ -31,7 +31,7 @@ func (s *StepMkfsImage) Run(_ context.Context, state multistep.StateBag) multist
 
 		if _, err := os.Stat(loopPartition); errors.Is(err, os.ErrNotExist) {
 			ui.Error(fmt.Sprintf("partition loopack `%s` doesn't exist immediately after mouting, delaying...", loopPartition)) // TODO: where's warning?
-  			time.Sleep(1 * time.Second)
+			time.Sleep(1 * time.Second)
 			if _, err := os.Stat(args[1]); errors.Is(err, os.ErrNotExist) {
 				ui.Error(fmt.Sprintf("partition loopack `%s` doesn't exist, aborting partition creation", loopPartition))
 				return multistep.ActionHalt


### PR DESCRIPTION
## Purpose

I don't think it's a bug, but behaviour of some OSes on very fast machines may impact how quickly the partition is mounted as loopback device as #72 claims. This adds a check if the loopback exists, delays 1 second if not, then checks again, if still doesn't breaks with error message (but then it's OS issue).

## Scope
- `builder/step/mkfs_image.go`