### PR TITLE
Open loopback partitions for writing

### DIFF
--- a/builder/step_map_image.go
+++ b/builder/step_map_image.go
@@ -36,6 +36,11 @@ func (s *StepMapImage) Run(_ context.Context, state multistep.StateBag) multiste
 	state.Put(s.ResultKey, s.loopDevice)
 	ui.Message(fmt.Sprintf("image %s mapped to %s", image, s.loopDevice))
 
+	out, err = exec.Command("partprobe").CombinedOutput()
+	if err != nil {
+		ui.Error(fmt.Sprintf("Failed to run partprobe: %s", err))
+	}
+
 	return multistep.ActionContinue
 }
 

--- a/builder/step_mkfs_image.go
+++ b/builder/step_mkfs_image.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"strings"
@@ -23,6 +24,25 @@ func (s *StepMkfsImage) Run(_ context.Context, state multistep.StateBag) multist
 	ui := state.Get("ui").(packer.Ui)
 	config := state.Get("config").(*Config)
 	loopDevice := state.Get(s.FromKey).(string)
+
+	for i, _ := range config.ImageConfig.ImagePartitions {
+		loopPartition := fmt.Sprintf("%sp%d", loopDevice, i+1)
+		for attempt := 0; ; attempt++ {
+			outFile, err := os.OpenFile(loopPartition, os.O_WRONLY, fs.ModeDevice)
+			if err == nil {
+				ui.Message(fmt.Sprintf("partition loopback `%s` is available for writing", loopPartition))
+				outFile.Close()
+				break
+			} else {
+				ui.Message(fmt.Sprintf("partition loopback `%s` cannot be written yet: %s", loopPartition, err))
+				if attempt >= 3 {
+					ui.Error(fmt.Sprintf("giving up on partition loopback `%s`", loopPartition))
+				} else {
+					time.Sleep(1 * time.Second)
+				}
+			}
+		}
+	}
 
 	for i, partition := range config.ImageConfig.ImagePartitions {
 		cmd := fmt.Sprintf("mkfs.%s", partition.Filesystem)


### PR DESCRIPTION
I tried out the delay added in this branch and it didn't seem to have much of an effect on the frequency with which `mkfs.vfat` failed. I've been having better luck with this alternative approach. I've run a few dozen builds with it without any failures.